### PR TITLE
Update scheme to "git" instead of "git+ssh:"

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "async": "~0.2.10",
     "bower": "~1.3.6",
-    "camunda-commons-ui": "git+ssh://git@github.com:camunda/camunda-commons-ui",
+    "camunda-commons-ui": "git://github.com/camunda/camunda-commons-ui",
     "grunt": "~0.4.0",
     "grunt-bower-task": "~0.3.4",
     "grunt-cli": "~0.1.0",


### PR DESCRIPTION
Hi,

Please change the scheme to git instead of "git+ssh". The latter would try to validate the certificate and fails to do an "npm install". Please do the needful.

-Nibin
